### PR TITLE
Update viewbag property names to match object

### DIFF
--- a/Quick_ACG/Views/Eg001EmbeddedSigning/quickEmbeddedSigning.cshtml
+++ b/Quick_ACG/Views/Eg001EmbeddedSigning/quickEmbeddedSigning.cshtml
@@ -51,23 +51,23 @@
       <p>@Html.Raw(ViewBag.CodeExampleText.ExampleDescription)</p>
 
      <p>
-        @if(ViewBag.CodeExampleText.LinksToAPIMethod.Count == 1)
+        @if(ViewBag.CodeExampleText.LinksToApiMethod.Count == 1)
         {
-            <span>@Html.Raw(ViewBag.SupportingTexts.APIMethodUsed)</span>
+            <span>@Html.Raw(ViewBag.SupportingTexts.ApiMethodUsed)</span>
         } 
         else
         {
-            <span>@Html.Raw(ViewBag.SupportingTexts.APIMethodUsedPlural)</span>
+            <span>@Html.Raw(ViewBag.SupportingTexts.ApiMethodUsedPlural)</span>
         }
 
-        @for(int i = 0; i < ViewBag.CodeExampleText.LinksToAPIMethod.Count; ++i)
+        @for(int i = 0; i < ViewBag.CodeExampleText.LinksToApiMethod.Count; ++i)
         {
-            <a target='_blank' href="@ViewBag.CodeExampleText.LinksToAPIMethod[i].Path">@Html.Raw(ViewBag.CodeExampleText.LinksToAPIMethod[i].PathName)</a>
-            @if(i + 1 == ViewBag.CodeExampleText.LinksToAPIMethod.Count)
+            <a target='_blank' href="@ViewBag.CodeExampleText.LinksToApiMethod[i].Path">@Html.Raw(ViewBag.CodeExampleText.LinksToApiMethod[i].PathName)</a>
+            @if(i + 1 == ViewBag.CodeExampleText.LinksToApiMethod.Count)
             {
                 <span>.</span>
             }
-            else if(i + 1 == ViewBag.CodeExampleText.LinksToAPIMethod.Count - 1)
+            else if(i + 1 == ViewBag.CodeExampleText.LinksToApiMethod.Count - 1)
             {
                 <span> and </span>
             }


### PR DESCRIPTION
CodeExampleText.LinksToApiMethod and SupportingTexts.ApiMethodUsedPlural incorrectly have capitalised Api when accessing the ViewBag which results in an exception, updated to 'Api' to match objects.

Closes #36 